### PR TITLE
Migrate `RaidEventListPage` to ListViewPage

### DIFF
--- a/files/lib/event/listView/user/RaidEventListViewInitialized.class.php
+++ b/files/lib/event/listView/user/RaidEventListViewInitialized.class.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace rp\event\listView\user;
+
+use rp\system\listView\user\RaidEventListView;
+use wcf\event\IPsr14Event;
+
+/**
+ * Indicates that the raid event list view has been initialized.
+ *
+ * @author  Marco Daries
+ * @copyright   2025 MD-Raidplaner
+ * @license MD-Raidplaner is licensed under Creative Commons Attribution-ShareAlike 4.0 International
+ */
+final class RaidEventListViewInitialized implements IPsr14Event
+{
+    public function __construct(public readonly RaidEventListView $listView) {}
+}

--- a/files/lib/page/RaidEventListPage.class.php
+++ b/files/lib/page/RaidEventListPage.class.php
@@ -2,20 +2,23 @@
 
 namespace rp\page;
 
-use rp\data\raid\event\I18nRaidEventList;
-use wcf\page\MultipleLinkPage;
+use rp\system\listView\user\RaidEventListView;
+use wcf\page\AbstractListViewPage;
 
 /**
- * Shows the raids page.
+ * Shows the raid event list page.
  *
  * @author  Marco Daries
  * @copyright   2025 MD-Raidplaner
  * @license MD-Raidplaner is licensed under Creative Commons Attribution-ShareAlike 4.0 International 
+ * 
+ * @extends AbstractListViewPage<RaidEventListView>
  */
-final class RaidEventListPage extends MultipleLinkPage
+final class RaidEventListPage extends AbstractListViewPage
 {
-    public $itemsPerPage = 60;
-    public $objectListClassName = I18nRaidEventList::class;
-    public $sortField = 'titleI18n';
-    public $sortOrder = 'ASC';
+    #[\Override]
+    protected function createListView(): RaidEventListView
+    {
+        return new RaidEventListView();
+    }
 }

--- a/files/lib/system/listView/user/RaidEventListView.class.php
+++ b/files/lib/system/listView/user/RaidEventListView.class.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace rp\system\listView\user;
+
+use rp\data\raid\event\I18nRaidEventList;
+use rp\event\listView\user\RaidEventListViewInitialized;
+use wcf\system\listView\AbstractListView;
+use wcf\system\listView\ListViewSortField;
+use wcf\system\WCF;
+
+/**
+ * List view for the list of raid events.
+ * 
+ * @author  Marco Daries
+ * @copyright   2025 MD-Raidplaner
+ * @license MD-Raidplaner is licensed under Creative Commons Attribution-ShareAlike 4.0 International 
+ * 
+ * @extends AbstractListView<RaidEventList>
+ */
+final class RaidEventListView extends AbstractListView
+{
+    public function __construct() {
+    $this->addAvailableSortFields([
+            new ListViewSortField('title', 'wcf.global.title', 'titleI18n'),
+        ]);
+
+        $this->setSortField('title');
+        $this->setItemsPerPage(60);
+    }
+
+    #[\Override]
+    protected function createObjectList(): I18nRaidEventList
+    {
+        return new I18nRaidEventList();
+    }
+
+    #[\Override]
+    protected function getInitializedEvent(): RaidEventListViewInitialized
+    {
+        return new RaidEventListViewInitialized($this);
+    }
+
+    #[\Override]
+    public function renderItems(): string
+    {
+        return WCF::getTPL()->render('rp', 'raidEventListItems', ['view' => $this]);
+    }
+}

--- a/templates/raidEventList.tpl
+++ b/templates/raidEventList.tpl
@@ -1,75 +1,28 @@
 {capture assign='pageTitle'}
-    {$__wcf->getActivePage()->getTitle()}{if $pageNo > 1} - {lang}wcf.page.pageNo{/lang}{/if}
+    {$__wcf->getActivePage()->getTitle()}
+    {if $listView->getPageNo() > 1} - {lang}wcf.page.pageNo{/lang}{/if}
 {/capture}
 {capture assign='contentTitle'}
-    {$__wcf->getActivePage()->getTitle()} <span class="badge">{#$items}</span>
+    {$__wcf->getActivePage()->getTitle()}
+    <span class="badge">{#$listView->countItems()}</span>
 {/capture}
 
 {capture assign='headContent'}
-    {if $pageNo < $pages}
-        <link rel="next" href="{link application='rp' controller='RaidEventList'}pageNo={$pageNo+1}{/link}">
+    {if $listView->getPageNo() < $listView->countPages()}
+        <link rel="next" href="{link application='rp' controller='RaidEventList'}pageNo={$listView->getPageNo() + 1}{/link}">
     {/if}
-    {if $pageNo > 1}
+    {if $listView->getPageNo() > 1}
         <link rel="prev"
-            href="{link application='rp' controller='RaidEventList'}{if $pageNo > 2}pageNo={$pageNo-1}{/if}{/link}">
+            href="{link application='rp' controller='RaidEventList'}{if $listView->getPageNo() > 2}pageNo={$listView->getPageNo() + 1}{/if}{/link}">
     {/if}
     <link rel="canonical"
-        href="{link application='rp' controller='RaidEventList'}{if $pageNo > 1}pageNo={$pageNo}{/if}{/link}">
-{/capture}
-
-{capture assign='contentInteractionPagination'}
-    <woltlab-core-pagination page="{$pageNo}" count="{$pages}"
-        url="{link application='rp' controller='RaidEventList'}{/link}">
-    </woltlab-core-pagination>
+        href="{link application='rp' controller='RaidEventList'}{if $listView->getPageNo() > 1}pageNo={$listView->getPageNo() + 1}{/if}{/link}">
 {/capture}
 
 {include file='header'}
 
-{if $objects|count}
-    <div class="section sectionContainerList">
-        <ol class="containerList pointList doubleColumned">
-            {foreach from=$objects item=event}
-                <li class="box64">
-                    {unsafe:$event->getIcon(64)}
-
-                    <div>
-                        <div class="containerHeadline">
-                            <h3>
-                                <a href="{$event->getLink()}">{$event->getTitle()}</a>
-                            </h3>
-                        </div>
-
-                        <dl class="plain dataList containerContent small">
-                            <dt>{lang}rp.raid.event.pointAccount{/lang}</dt>
-                            <dd>{if $event->getPointAccount()}{$event->getPointAccount()->getTitle()}{else}-{/if}</dd>
-                        </dl>
-                    </div>
-                </li>
-            {/foreach}
-        </ol>
-    </div>
-
-    <footer class="contentFooter">
-        {hascontent}
-        <div class="paginationBottom">
-            {content}
-            <woltlab-core-pagination page="{$pageNo}" count="{$pages}"
-                url="{link application='rp' controller='RaidEventList'}{/link}">
-            </woltlab-core-pagination>
-            {/content}
-        </div>
-        {/hascontent}
-
-        {hascontent}
-        <nav class="contentFooterNavigation">
-            <ul>
-                {content}{event name='contentFooterNavigation'}{/content}
-            </ul>
-        </nav>
-        {/hascontent}
-    </footer>
-{else}
-    <woltlab-core-notice type="info">{lang}wcf.global.noItems{/lang}</woltlab-core-notice>
-{/if}
+<div class="section">
+    {unsafe:$listView->render()}
+</div>
 
 {include file='footer'}

--- a/templates/raidEventListItems.tpl
+++ b/templates/raidEventListItems.tpl
@@ -1,0 +1,36 @@
+<div class="contentItemList">
+    {foreach from=$view->getItems() item=event}
+        <div class="contentItem contentItemMultiColumn listView__item" data-object-id="{$event->getObjectID()}">
+            <div class="contentItemOptions">
+                {if $view->hasBulkInteractions()}
+                    <label class="button small jsTooltip" title="{lang}wcf.clipboard.item.mark{/lang}">
+                        <input type="checkbox" class="listView__selectItem" aria-label="{lang}wcf.clipboard.item.mark{/lang}">
+                    </label>
+                {/if}
+
+                {unsafe:$view->renderInteractionContextMenuButton($event)}
+            </div>
+
+            <div class="contentItemLink">
+                <div class="contentItemImage">
+                    {unsafe:$event->getIcon(64)}
+                </div>
+            </div>
+
+            <div class="contentItemContent">
+                <h2 class="contentItemTitle">
+                    <a href="{$event->getLink()}" class="contentItemTitleLink">
+                        {$event->getTitle()}
+                    </a>
+                </h2>
+
+                <div class="contentItemDescription">
+                    <dl class="plain dataList containerContent small">
+                        <dt>{lang}rp.raid.event.pointAccount{/lang}</dt>
+                        <dd>{if $event->getPointAccount()}{$event->getPointAccount()->getTitle()}{else}-{/if}</dd>
+                    </dl>
+                </div>
+            </div>
+        </div>
+    {/foreach}
+</div>


### PR DESCRIPTION
Introduce a new list view for displaying raid events along with the necessary templates and initialization logic. This enhances the user interface for managing and viewing raid events.